### PR TITLE
fix: changes policy name to name_prefix

### DIFF
--- a/app_account_role.tf
+++ b/app_account_role.tf
@@ -28,7 +28,7 @@ module "app_account_role" {
 ###############################################################################
 
 resource "aws_iam_policy" "manage_apps" {
-  name        = "ManageApplicationResources"
+  name_prefix = "ManageApplicationResources"
   description = "Policy to permit management of ${var.resource_prefix} application resources"
   policy      = data.aws_iam_policy_document.manage_apps.json
   tags        = var.tags

--- a/data_account_role.tf
+++ b/data_account_role.tf
@@ -28,7 +28,7 @@ module "data_account_role" {
 ###############################################################################
 
 resource "aws_iam_policy" "manage_data_account" {
-  name        = "ManageDataAccountResources"
+  name_prefix = "ManageDataAccountResources"
   description = "Policy to permit management of ${var.resource_prefix} data account resources"
   policy      = data.aws_iam_policy_document.manage_data_account.json
   tags        = var.tags


### PR DESCRIPTION
**JIRA**: ANPL-1160

## What has changed?

BREAKING CHANGE: policy name parameter changed to name_prefix

## Why is this needed?

The policies created to manage apps and data accounts used fixed
names which caused a clash when deployed multiple times in the
same account.

## What should the reviewer concentrate on?

- Code quality
- Design
