### PR TITLE
fix AWS provider constraint

### DIFF
--- a/test/versions.tf
+++ b/test/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.71.0"
+      version = ">= 3.71.0"
     }
   }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.71.0"
+      version = ">= 3.71.0"
       configuration_aliases = [
         aws.apps_account,
         aws.data_account,


### PR DESCRIPTION
[#927](https://github.com/ministryofjustice/analytics-platform-infrastructure/issues/927)

## What has changed?

Updated AWS provider to >=3.71.0

## Why is this needed?

Fixes a constraint error in analytical-platform-infratstucture repo that happens when trying to upgrade the AWS provider.

## What should the reviewer concentrate on?

Correct version, syntax
